### PR TITLE
Build strings with append, improve tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,6 @@ func TestExample(t *testing.T) {
 	err := rg.AddNode(&john)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	japan := Node{
@@ -38,7 +37,6 @@ func TestExample(t *testing.T) {
 	err = rg.AddNode(&japan)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	edge := Edge{
@@ -49,13 +47,11 @@ func TestExample(t *testing.T) {
 	err = rg.AddEdge(&edge)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	_, err = rg.Commit()
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	query := `MATCH (p:person)-[v:visited]->(c:country)
@@ -63,7 +59,6 @@ func TestExample(t *testing.T) {
 	rs, err := rg.Query(query)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 
 	rs.PrettyPrint()
@@ -86,23 +81,19 @@ func TestFlush(t *testing.T) {
 		err := rg.AddNode(&family)
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		_, err = rg.Flush()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 	}
 	query := `MATCH (p:person) RETURN p.name`
 	rs, err := rg.Query(query)
 	if err != nil {
 		t.Error(err)
-		t.Fail()
 	}
 	if len(rs.Results) > 4 {
 		t.Errorf("There Should only be 4 entries but we get: %d", len(rs.Results))
-		t.Fail()
 	}
 
 }

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,11 @@ func TestExample(t *testing.T) {
 			"status": "single",
 		},
 	}
-	rg.AddNode(&john)
+	err := rg.AddNode(&john)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 
 	japan := Node{
 		Label: "country",
@@ -31,20 +35,36 @@ func TestExample(t *testing.T) {
 			"name": "Japan",
 		},
 	}
-	rg.AddNode(&japan)
+	err = rg.AddNode(&japan)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 
 	edge := Edge{
 		Source:      &john,
 		Relation:    "visited",
 		Destination: &japan,
 	}
-	rg.AddEdge(&edge)
+	err = rg.AddEdge(&edge)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 
-	rg.Commit()
+	_, err = rg.Commit()
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 
 	query := `MATCH (p:person)-[v:visited]->(c:country)
 		   RETURN p.name, p.age, v.purpose, c.name`
-	rs, _ := rg.Query(query)
+	rs, err := rg.Query(query)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 
 	rs.PrettyPrint()
 }
@@ -63,13 +83,26 @@ func TestFlush(t *testing.T) {
 				"name": fmt.Sprintf("%s Rubble", user),
 			},
 		}
-		rg.AddNode(&family)
-		rg.Flush()
+		err := rg.AddNode(&family)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+		_, err = rg.Flush()
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
 	}
 	query := `MATCH (p:person) RETURN p.name`
-	rs, _ := rg.Query(query)
+	rs, err := rg.Query(query)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
 	if len(rs.Results) > 4 {
 		t.Errorf("There Should only be 4 entries but we get: %d", len(rs.Results))
+		t.Fail()
 	}
 
 }


### PR DESCRIPTION
- Instead of using `+=`, append strings into slice then merge them with `strings.Join` - will make it build longer query strings faster
- Added fail statements to tests to make it clear when something is wrong
- Added error logging to tests so that if an error comes back from the client while running the tests, that error is printed