### PR TITLE
Extended client with examples folder and godoc with 3 examples …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,7 @@ jobs:
     working_directory: /go/src/github.com/RedisGraph/redisgraph-go
     steps:
       - checkout
-      - run: go get -v -t -d ./...
-      - run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
+      - run: make test
       - early_return_for_forked_pull_requests
       - run: bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
       

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+*
+!/**/
+!**/*.go
+!.gitignore
+!.circleci/config.yml
+!/tests/*.bz2
+!Makefile
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+coverage.txt
+
+.idea
+.project
+
+vendor/
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOINSTALL=$(GOCMD) install
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+
+.PHONY: all test coverage
+all: test coverage examples
+
+get:
+	$(GOGET) -t -v ./...
+
+TLS_CERT ?= redis.crt
+TLS_KEY ?= redis.key
+TLS_CACERT ?= ca.crt
+REDISGRAPH_TEST_HOST ?= 127.0.0.1:6379
+
+examples: get
+	@echo " "
+	@echo "Building the examples..."
+	$(GOBUILD) ./examples/redisgraph_tls_client/.
+	./redisgraph_tls_client --tls-cert-file $(TLS_CERT) \
+						 --tls-key-file $(TLS_KEY) \
+						 --tls-ca-cert-file $(TLS_CACERT) \
+						 --host $(REDISGRAPH_TEST_HOST)
+
+test: get
+	$(GOTEST) -race -covermode=atomic ./...
+
+coverage: get test
+	$(GOTEST) -race -coverprofile=coverage.txt -covermode=atomic ./...
+

--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,10 @@ all: test coverage examples
 get:
 	$(GOGET) -t -v ./...
 
-TLS_CERT ?= redis.crt
-TLS_KEY ?= redis.key
-TLS_CACERT ?= ca.crt
-REDISGRAPH_TEST_HOST ?= 127.0.0.1:6379
-
 examples: get
 	@echo " "
 	@echo "Building the examples..."
 	$(GOBUILD) ./examples/redisgraph_tls_client/.
-	./redisgraph_tls_client --tls-cert-file $(TLS_CERT) \
-						 --tls-key-file $(TLS_KEY) \
-						 --tls-ca-cert-file $(TLS_CACERT) \
-						 --host $(REDISGRAPH_TEST_HOST)
 
 test: get
 	$(GOTEST) -race -covermode=atomic ./...

--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -100,6 +100,7 @@ func ExampleGraphNew_tls() {
 	q := "CREATE (w:WorkPlace {name:'RedisLabs'}) RETURN w"
 	res, _ := graph.Query(q)
 
+	res.Next()
 	r := res.Record()
 	w := r.GetByIndex(0).(*redisgraph.Node)
 	fmt.Println(w.Label)

--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -28,9 +28,8 @@ func ExampleGraphNew() {
 
 func ExampleGraphNew_pool() {
 	host := "localhost:6379"
-	password := ""
 	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
-		return redis.Dial("tcp", host, redis.DialPassword(password))
+		return redis.Dial("tcp", host)
 	}}
 
 	graph := redisgraph.GraphNew("social", pool.Get())

--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -1,0 +1,167 @@
+package redisgraph_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"github.com/RedisGraph/redisgraph-go"
+	"github.com/gomodule/redigo/redis"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func ExampleGraphNew() {
+	conn, _ := redis.Dial("tcp", "0.0.0.0:6379")
+
+	graph := redisgraph.GraphNew("social", conn)
+
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	res, _ := graph.Query(q)
+
+	q = "MATCH (w:WorkPlace) RETURN w"
+	res, _ = graph.Query(q)
+
+	res.Next()
+	r := res.Record()
+	w := r.GetByIndex(0).(*redisgraph.Node)
+	fmt.Println(w.Label)
+	// Output: WorkPlace
+}
+
+func ExampleGraphNew_pool() {
+	host := "localhost:6379"
+	password := ""
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", host, redis.DialPassword(password))
+	}}
+
+	graph := redisgraph.GraphNew("social", pool.Get())
+
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	res, _ := graph.Query(q)
+
+	q = "MATCH (w:WorkPlace) RETURN w"
+	res, _ = graph.Query(q)
+
+	res.Next()
+	r := res.Record()
+	w := r.GetByIndex(0).(*redisgraph.Node)
+	fmt.Println(w.Label)
+	// Output: WorkPlace
+
+}
+
+func ExampleGraphNew_tls() {
+	// Consider the following helper methods that provide us with the connection details (host and password)
+	// and the paths for:
+	//     tls_cert - A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted
+	//     tls_key - A a X.509 private key to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted
+	//	   tls_cacert - A PEM encoded CA's certificate file
+	host, password := getConnectionDetails()
+	tlsready, tls_cert, tls_key, tls_cacert := getTLSdetails()
+
+	// Skip if we dont have all files to properly connect
+	if tlsready == false {
+		return
+	}
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(tls_cert, tls_key)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(tls_cacert)
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate
+	// presented by the server and any host name in that certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// This should be used only for testing.
+	clientTLSConfig.InsecureSkipVerify = true
+
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", host,
+			redis.DialPassword(password),
+			redis.DialTLSConfig(clientTLSConfig),
+			redis.DialUseTLS(true),
+			redis.DialTLSSkipVerify(true),
+		)
+	}}
+
+	graph := redisgraph.GraphNew("social", pool.Get())
+
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	res, err := graph.Query(q)
+
+	q = "MATCH (w:WorkPlace) RETURN w"
+	res, err = graph.Query(q)
+
+	res.Next()
+	r := res.Record()
+	w := r.GetByIndex(0).(*redisgraph.Node)
+	fmt.Println(w.Label)
+}
+
+func getConnectionDetails() (host string, password string) {
+	value, exists := os.LookupEnv("REDISGRAPH_TEST_HOST")
+	host = "localhost:6379"
+	password = ""
+	valuePassword, existsPassword := os.LookupEnv("REDISGRAPH_TEST_PASSWORD")
+	if exists && value != "" {
+		host = value
+	}
+	if existsPassword && valuePassword != "" {
+		password = valuePassword
+	}
+	return
+}
+
+func getTLSdetails() (tlsready bool, tls_cert string, tls_key string, tls_cacert string) {
+	tlsready = false
+	value, exists := os.LookupEnv("TLS_CERT")
+	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
+		tls_cert = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_KEY")
+	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
+		tls_key = value
+	} else {
+		return
+	}
+	value, exists = os.LookupEnv("TLS_CACERT")
+	if exists && value != "" {
+		info, err := os.Stat(value)
+		if os.IsNotExist(err) || info.IsDir() {
+			return
+		}
+		tls_cacert = value
+	} else {
+		return
+	}
+	tlsready = true
+	return
+}

--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -16,11 +16,8 @@ func ExampleGraphNew() {
 
 	graph := redisgraph.GraphNew("social", conn)
 
-	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'}) RETURN w"
 	res, _ := graph.Query(q)
-
-	q = "MATCH (w:WorkPlace) RETURN w"
-	res, _ = graph.Query(q)
 
 	res.Next()
 	r := res.Record()
@@ -38,11 +35,8 @@ func ExampleGraphNew_pool() {
 
 	graph := redisgraph.GraphNew("social", pool.Get())
 
-	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'}) RETURN w"
 	res, _ := graph.Query(q)
-
-	q = "MATCH (w:WorkPlace) RETURN w"
-	res, _ = graph.Query(q)
 
 	res.Next()
 	r := res.Record()
@@ -104,13 +98,9 @@ func ExampleGraphNew_tls() {
 
 	graph := redisgraph.GraphNew("social", pool.Get())
 
-	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
-	res, err := graph.Query(q)
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'}) RETURN w"
+	res, _ := graph.Query(q)
 
-	q = "MATCH (w:WorkPlace) RETURN w"
-	res, err = graph.Query(q)
-
-	res.Next()
 	r := res.Record()
 	w := r.GetByIndex(0).(*redisgraph.Node)
 	fmt.Println(w.Label)
@@ -119,11 +109,11 @@ func ExampleGraphNew_tls() {
 func getConnectionDetails() (host string, password string) {
 	value, exists := os.LookupEnv("REDISGRAPH_TEST_HOST")
 	host = "localhost:6379"
-	password = ""
-	valuePassword, existsPassword := os.LookupEnv("REDISGRAPH_TEST_PASSWORD")
 	if exists && value != "" {
 		host = value
 	}
+	password = ""
+	valuePassword, existsPassword := os.LookupEnv("REDISGRAPH_TEST_PASSWORD")
 	if existsPassword && valuePassword != "" {
 		password = valuePassword
 	}

--- a/examples/redisgraph_tls_client/redisgraph_tls_client.go
+++ b/examples/redisgraph_tls_client/redisgraph_tls_client.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"github.com/RedisGraph/redisgraph-go"
+	"github.com/gomodule/redigo/redis"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var (
+	tlsCertFile   = flag.String("tls-cert-file", "redis.crt", "A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted.")
+	tlsKeyFile    = flag.String("tls-key-file", "redis.key", "A a X.509 privat ekey to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted.")
+	tlsCaCertFile = flag.String("tls-ca-cert-file", "ca.crt", "A PEM encoded CA's certificate file.")
+	host          = flag.String("host", "127.0.0.1:6379", "Redis host.")
+	password      = flag.String("password", "", "Redis password.")
+)
+
+func exists(filename string) (exists bool) {
+	exists = false
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) || info.IsDir() {
+		return
+	}
+	exists = true
+	return
+}
+
+/*
+ * Example of how to establish an SSL connection from your app to the RedisAI Server
+ */
+func main() {
+	flag.Parse()
+	// Quickly check if the files exist
+	if !exists(*tlsCertFile) || !exists(*tlsKeyFile) || !exists(*tlsCaCertFile) {
+		fmt.Println("Some of the required files does not exist. Leaving example...")
+		return
+	}
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(*tlsCertFile, *tlsKeyFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(*tlsCaCertFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate
+	// presented by the server and any host name in that certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// This should be used only for testing.
+	clientTLSConfig.InsecureSkipVerify = true
+
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", *host,
+			redis.DialPassword(*password),
+			redis.DialTLSConfig(clientTLSConfig),
+			redis.DialUseTLS(true),
+			redis.DialTLSSkipVerify(true),
+		)
+	}}
+
+	graph := redisgraph.GraphNew("social", pool.Get())
+
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
+	res, err := graph.Query(q)
+
+	q = "MATCH (w:WorkPlace) RETURN w"
+	res, err = graph.Query(q)
+
+	res.Next()
+	r := res.Record()
+	w := r.GetByIndex(0).(*redisgraph.Node)
+	fmt.Println(w.Label)
+	// Output: WorkPlace
+}

--- a/examples/redisgraph_tls_client/redisgraph_tls_client.go
+++ b/examples/redisgraph_tls_client/redisgraph_tls_client.go
@@ -79,11 +79,8 @@ func main() {
 
 	graph := redisgraph.GraphNew("social", pool.Get())
 
-	q := "CREATE (w:WorkPlace {name:'RedisLabs'})"
-	res, err := graph.Query(q)
-
-	q = "MATCH (w:WorkPlace) RETURN w"
-	res, err = graph.Query(q)
+	q := "CREATE (w:WorkPlace {name:'RedisLabs'}) RETURN w"
+	res, _ := graph.Query(q)
 
 	res.Next()
 	r := res.Record()


### PR DESCRIPTION
Extended the client with examples folder and godoc with 3 examples on how to connect to the RedisGraph Server. ( simplest way possible, with pool, and with SSL )
The examples (with exception to tls ) are part of the tests ( via the `Output: ...` directive ). Here is the aspect of it:
![image](https://user-images.githubusercontent.com/5832149/81585548-3ae58600-93ac-11ea-983e-3b37da9d171f.png)
Regarding tls support it is also included as pluggable example given that it's more complex and users can get the example working on their system very quickly. ( we're making it have the same look and feel across all modules ). Regarding testing of the tls examples (lets wait a bit for the redisgraph:edge to be able to support it --matter of days ) given that the docker images requires openmp and other dependencies and hacking around it is more difficult than on other modules. 
To test tls example locally:
```
redis-server --tls-port 6380 --port 6379 --tls-cert-file <path_to>/redis.crt --tls-key-file <path_to>/redis.key  --tls-ca-cert-file <path_to>/ca.crt   --loadmodule <path_to>/redisgraph.so
```
then on the go client:
```
$> TLS_CERT=<path_to>/redis.crt TLS_KEY=<path_to>/redis.key TLS_CACERT=/<path_to>/ca.crt REDISGRAPH_TEST_HOST=127.0.0.1:6380 make examples
go get -t -v ./...
 
Building the examples...
go build ./examples/redisgraph_tls_client/.
./redisgraph_tls_client --tls-cert-file <path_to>/redis.crt \
                                         --tls-key-file <path_to>/redis.key \
                                         --tls-ca-cert-file <path_to>/ca.crt \
                                         --host 127.0.0.1:6380
WorkPlace
```