### PR TITLE
Fix: Introduced InternalExecutionTime() and removed RunTime()

### DIFF
--- a/query_result.go
+++ b/query_result.go
@@ -361,7 +361,8 @@ func (qr *QueryResult) IndicesDeleted() int {
 	return int(qr.getStat(INDICES_DELETED))
 }
 
-func (qr *QueryResult) RunTime() float64 {
+// Returns the query internal execution time in milliseconds
+func (qr *QueryResult) InternalExecutionTime() float64 {
 	return qr.getStat(INTERNAL_EXECUTION_TIME)
 }
 


### PR DESCRIPTION
The following PR removes RunTime() and introduces InternalExecutionTime().
Apart from it, the PR also introduces further testing to avoid unnoticed breakage in the future
