### PR TITLE
Support for []string within ToString() function

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,17 @@ func arrayToString(arr []interface{}) string {
 	return "[" + strings.Join(strArray, ",") + "]"
 }
 
+// go array to string is [1 2 3] for [1, 2, 3] array
+// cypher expects comma separated array
+func strArrayToString(arr []string) string {
+	var arrayLength = len(arr)
+	strArray := []string{}
+	for i := 0; i < arrayLength; i++ {
+		strArray = append(strArray, ToString(arr[i]))
+	}
+	return "[" + strings.Join(strArray, ",") + "]"
+}
+
 func mapToString(data map[string]interface{}) string {
 	pairsArray := []string{}
 	for k, v := range data {
@@ -47,6 +58,9 @@ func ToString(i interface{}) string {
 	case map[string]interface{}:
 		data := i.(map[string]interface{})
 		return mapToString(data)
+	case []string:
+		arr := i.([]string)
+		return strArrayToString(arr)
 	default:
 		panic("Unrecognized type to convert to string")
 	}


### PR DESCRIPTION
This PR closes the missing gap to fix #30. The map support was already addressed by @AvitalFineRedis on #47 so we just need to support `[]string` type within `ToString()` function. 
Included as a test the use-case raised on #30 by @sankarvj