### PR TITLE
Add new type that can be parametrized.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -420,10 +420,13 @@ func TestUtils(t *testing.T) {
 	res = ToString(true)
 	assert.Equal(t, res, "true")
 
-	var arr = []interface{}{1,2,3,"boom"}
+	res = ToString(int64(10))
+	assert.Equal(t, res, "10")
+
+	var arr = []interface{}{1, 2, 3, int64(4), "boom"}
 	res = ToString(arr)
-	assert.Equal(t, res, "[1,2,3,\"boom\"]")
-	
+	assert.Equal(t, res, "[1,2,3,4,\"boom\"]")
+
 	jsonMap := make(map[string]interface{})
 	jsonMap["object"] = map[string]interface{} {"foo": 1}
 	res = ToString(jsonMap)

--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,8 @@ func ToString(i interface{}) string {
 		return strconv.Quote(s)
 	case int:
 		return strconv.Itoa(i.(int))
+	case int64:
+		return strconv.FormatInt(i.(int64), 10)
 	case float64:
 		return strconv.FormatFloat(i.(float64), 'f', -1, 64)
 	case bool:


### PR DESCRIPTION
Hello,

When using `redisgraph-go` you cannot simply pass `time.Now().Unix()` as ParameterizedQuery parameter, which I though is common behavior. Example code below.

```go
if _, err := graph.ParameterizedQuery(query, map[string]interface{}{
	"task_id":   id,
        "now":       time.Now().Unix(),
}); err != nil {
        return fmt.Errorf("graph.ParameterizedQuery: %w", err)
}
```

Probably I can use `toInteger` RedisGraphs function in query, but I still won't be able to pass `int64` as property in `Properties` field of Nodes.

What do you think about that?