### PR TITLE
[FIX] Avoid getting label by negative index

### DIFF
--- a/query_result.go
+++ b/query_result.go
@@ -176,7 +176,7 @@ func (qr *QueryResult) parseNode(cell interface{}) *Node {
 	c, _ := redis.Values(cell, nil)
 	id, _ := redis.Uint64(c[0], nil)
 	labels, _ := redis.Ints(c[1], nil)
-	if len(labels) > 0 {
+	if len(labels) > 0 && labels[0] >= 0 {
 		label = qr.graph.getLabel(labels[0])
 	}
 


### PR DESCRIPTION
I've not diagnosed rhe root cause; hopefully this points to it though.

With a query, "MATCH (s)-[r:incs]-(l:EC) WHERE ID(s)=3 RETURN r,l", which should be retrieving:

127.0.0.1:6379> GRAPH.QUERY G:1 "MATCH (s)-[r:incs]-(l:EC) WHERE ID(s)=3 RETURN r,l"
1) 1) "r"
   2) "l"
2) 1) 1) 1) 1) "id"
            2) (integer) 4
         2) 1) "type"
            2) "incs"
         3) 1) "src_node"
            2) (integer) 3
         4) 1) "dest_node"
            2) (integer) 6
         5) 1) "properties"
            2) 1) 1) "Net"
                  2) "c4peu14uj9oqljf5dkn0"
      2) 1) 1) "id"
            2) (integer) 6
         2) 1) "labels"
            2) 1) "EC"
         3) 1) "properties"
            2) 1) 1) "IDs"
                  2) "[0, 4, 3]"

I instead get:

runtime error: index out of range [-2]
goroutine 210 [running]:
net/http.(*conn).serve.func1(0xc0002fc140)
	/usr/lib/go-1.16/src/net/http/server.go:1824 +0x153
panic(0x9842e0, 0xc0014c04b0)
	/usr/lib/go-1.16/src/runtime/panic.go:971 +0x499
github.com/redislabs/redisgraph-go.(*Graph).getLabel(0xc0018faea0, 0xfffffffffffffffe, 0x0, 0x0)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/graph.go:141 +0x152
github.com/redislabs/redisgraph-go.(*QueryResult).parseNode(0xc0017e5e00, 0x908040, 0xc00081adf8, 0x0)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/query_result.go:179 +0x219
github.com/redislabs/redisgraph-go.(*QueryResult).parseScalar(0xc0017e5e00, 0xc001461cc0, 0x2, 0x2, 0xc001461cc0, 0x2)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/query_result.go:257 +0x2b7
github.com/redislabs/redisgraph-go.(*QueryResult).parseRecords(0xc0017e5e00, 0xc0017d2d80, 0x3, 0x3)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/query_result.go:139 +0x434
github.com/redislabs/redisgraph-go.(*QueryResult).parseResults(0xc0017e5e00, 0xc0017d2d80, 0x3, 0x3)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/query_result.go:99 +0x77
github.com/redislabs/redisgraph-go.QueryResultNew(0xc0018faea0, 0x908040, 0xc00081aea0, 0xc0017d2d20, 0x3, 0x3)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/query_result.go:85 +0x1da
github.com/redislabs/redisgraph-go.(*Graph).Query(0xc0018faea0, 0xc0013cba80, 0x32, 0x7effa2628108, 0x40, 0xc0013cba80)
	~/Dev/go/pkg/mod/github.com/redislabs/redisgraph-go@v2.0.2+incompatible/graph.go:108 +0x171