### PR TITLE
Add more numeric type support for Parameterized Queries

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -410,24 +410,42 @@ func TestUtils(t *testing.T) {
 
 	res = ToString("test_string")
 	assert.Equal(t, res, "\"test_string\"")
-	
-	res = ToString(10)
-	assert.Equal(t, res, "10")	
 
-	res = ToString(1.2)
+	res = ToString(10)
+	assert.Equal(t, res, "10")
+
+	res = ToString(float64(1.2))
+	assert.Equal(t, res, "1.2")
+
+	res = ToString(int64(-3))
+	assert.Equal(t, res, "-3")
+
+	res = ToString(int32(-4))
+	assert.Equal(t, res, "-4")
+
+	res = ToString(uint(3))
+	assert.Equal(t, res, "3")
+
+	res = ToString(uint64(3))
+	assert.Equal(t, res, "3")
+
+	res = ToString(uint32(3))
+	assert.Equal(t, res, "3")
+
+	res = ToString(float32(1.2))
 	assert.Equal(t, res, "1.2")
 
 	res = ToString(true)
 	assert.Equal(t, res, "true")
 
-	var arr = []interface{}{1,2,3,"boom"}
+	var arr = []interface{}{1, 2, 3, "boom", int64(-40)}
 	res = ToString(arr)
-	assert.Equal(t, res, "[1,2,3,\"boom\"]")
-	
+	assert.Equal(t, res, "[1,2,3,\"boom\",-40]")
+
 	jsonMap := make(map[string]interface{})
-	jsonMap["object"] = map[string]interface{} {"foo": 1}
+	jsonMap["object"] = map[string]interface{}{"foo": 1, "bar": float32(4.3)}
 	res = ToString(jsonMap)
-	assert.Equal(t, res, "{object: {foo: 1}}")
+	assert.Equal(t, res, "{object: {foo: 1,bar: 4.3}}")
 }
 
 func TestNodeMapDatatype(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -48,8 +48,20 @@ func ToString(i interface{}) string {
 		return strconv.Quote(s)
 	case int:
 		return strconv.Itoa(i.(int))
+	case int64:
+		return strconv.FormatInt(i.(int64), 10)
+	case int32:
+		return strconv.FormatInt(int64(i.(int32)), 10)
+	case uint:
+		return strconv.FormatUint(uint64(i.(uint)), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(i.(uint32)), 10)
+	case uint64:
+		return strconv.FormatUint(i.(uint64), 10)
 	case float64:
 		return strconv.FormatFloat(i.(float64), 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(i.(float32)), 'f', -1, 32)
 	case bool:
 		return strconv.FormatBool(i.(bool))
 	case []interface{}:


### PR DESCRIPTION
Support and tests for:
- int64, int32
- uint, uint64, uint32,
- float32

Use cases:
- a unix timestamp (that is of type int64) has to be serialized
- a variable coming from a protobuf generated type (that does not support int, but only int32 and int64) has to be serialized