### PR TITLE
query_result: Parse all integers as int64

### DIFF
--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -8,12 +8,15 @@ import (
 	"log"
 	"os"
 
-	"github.com/RedisGraph/redisgraph-go"
 	"github.com/gomodule/redigo/redis"
+
+	"github.com/RedisGraph/redisgraph-go"
 )
 
+const port = 6379
+
 func ExampleGraphNew() {
-	conn, _ := redis.Dial("tcp", "0.0.0.0:6379")
+	conn, _ := redis.Dial("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 
 	graph := redisgraph.GraphNew("social", conn)
 
@@ -28,7 +31,7 @@ func ExampleGraphNew() {
 }
 
 func ExampleGraphNew_pool() {
-	host := "localhost:6379"
+	host := fmt.Sprintf("0.0.0.0:%d", port)
 	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
 		return redis.Dial("tcp", host)
 	}}
@@ -109,7 +112,7 @@ func ExampleGraphNew_tls() {
 
 func getConnectionDetails() (host string, password string) {
 	value, exists := os.LookupEnv("REDISGRAPH_TEST_HOST")
-	host = "localhost:6379"
+	host = fmt.Sprintf("0.0.0.0:%d", port)
 	if exists && value != "" {
 		host = value
 	}

--- a/query_result.go
+++ b/query_result.go
@@ -55,11 +55,11 @@ type QueryResultHeader struct {
 
 // QueryResult represents the results of a query.
 type QueryResult struct {
-	graph              *Graph
-	header             QueryResultHeader
-	results            []*Record
-	statistics         map[string]float64
-	currentRecordIdx   int
+	graph            *Graph
+	header           QueryResultHeader
+	results          []*Record
+	statistics       map[string]float64
+	currentRecordIdx int
 }
 
 func QueryResultNew(g *Graph, response interface{}) (*QueryResult, error) {
@@ -70,7 +70,7 @@ func QueryResultNew(g *Graph, response interface{}) (*QueryResult, error) {
 			column_names: make([]string, 0),
 			column_types: make([]ResultSetColumnTypes, 0),
 		},
-		graph:              g,
+		graph:            g,
 		currentRecordIdx: -1,
 	}
 
@@ -251,7 +251,7 @@ func (qr *QueryResult) parseScalar(cell []interface{}) interface{} {
 		s, _ = redis.String(v, nil)
 
 	case VALUE_INTEGER:
-		s, _ = redis.Int(v, nil)
+		s, _ = redis.Int64(v, nil)
 
 	case VALUE_BOOLEAN:
 		s, _ = redis.Bool(v, nil)

--- a/utils.go
+++ b/utils.go
@@ -3,8 +3,8 @@ package redisgraph
 import (
 	"crypto/rand"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // go array to string is [1 2 3] for [1, 2, 3] array
@@ -32,35 +32,39 @@ func strArrayToString(arr []string) string {
 func mapToString(data map[string]interface{}) string {
 	pairsArray := []string{}
 	for k, v := range data {
-		pairsArray = append(pairsArray, k + ": " + ToString(v))
+		pairsArray = append(pairsArray, k+": "+ToString(v))
 	}
 	return "{" + strings.Join(pairsArray, ",") + "}"
 }
 
 func ToString(i interface{}) string {
-	if(i == nil) {
+	if i == nil {
 		return "null"
 	}
 
-	switch i.(type) {
+	switch val := i.(type) {
 	case string:
-		s := i.(string)
-		return strconv.Quote(s)
+		return strconv.Quote(val)
+	case fmt.Stringer:
+		return strconv.Quote(val.String())
 	case int:
-		return strconv.Itoa(i.(int))
+		return strconv.Itoa(val)
+	case int32:
+		return strconv.FormatInt(int64(val), 10)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case float32:
+		return strconv.FormatFloat(float64(val), 'f', -1, 64)
 	case float64:
-		return strconv.FormatFloat(i.(float64), 'f', -1, 64)
+		return strconv.FormatFloat(val, 'f', -1, 64)
 	case bool:
-		return strconv.FormatBool(i.(bool))
+		return strconv.FormatBool(val)
 	case []interface{}:
-		arr := i.([]interface{})
-		return arrayToString(arr)
+		return arrayToString(val)
 	case map[string]interface{}:
-		data := i.(map[string]interface{})
-		return mapToString(data)
+		return mapToString(val)
 	case []string:
-		arr := i.([]string)
-		return strArrayToString(arr)
+		return strArrayToString(val)
 	default:
 		panic("Unrecognized type to convert to string")
 	}
@@ -91,7 +95,7 @@ func RandomString(n int) string {
 	return string(output)
 }
 
-func BuildParamsHeader(params map[string]interface{}) (string) {
+func BuildParamsHeader(params map[string]interface{}) string {
 	header := "CYPHER "
 	for key, value := range params {
 		header += fmt.Sprintf("%s=%v ", key, ToString(value))


### PR DESCRIPTION
The public implementation of redisgraph-go parses all numbers as 'int' rather than 'int64'. This is especially bad for int32 timestamp values, since they will overflow in 2038. We should instead parse all number values as int64.